### PR TITLE
Include `error` return value to satisfy updated FieldResolveFn type

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -29,10 +29,10 @@ func NewConnectionArgs(configMap graphql.FieldConfigArgument) graphql.FieldConfi
 }
 
 type ConnectionConfig struct {
-	Name             string                 `json:"name"`
-	NodeType         *graphql.Object        `json:"nodeType"`
-	EdgeFields       graphql.Fields `json:"edgeFields"`
-	ConnectionFields graphql.Fields `json:"connectionFields"`
+	Name             string          `json:"name"`
+	NodeType         *graphql.Object `json:"nodeType"`
+	EdgeFields       graphql.Fields  `json:"edgeFields"`
+	ConnectionFields graphql.Fields  `json:"connectionFields"`
 }
 
 type EdgeType struct {

--- a/connection_test.go
+++ b/connection_test.go
@@ -38,16 +38,16 @@ func init() {
 		EdgeFields: graphql.Fields{
 			"friendshipTime": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) interface{} {
-					return "Yesterday"
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return "Yesterday", nil
 				},
 			},
 		},
 		ConnectionFields: graphql.Fields{
 			"totalCount": &graphql.Field{
 				Type: graphql.Int,
-				Resolve: func(p graphql.ResolveParams) interface{} {
-					return len(connectionTestAllUsers)
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return len(connectionTestAllUsers), nil
 				},
 			},
 		},
@@ -57,10 +57,10 @@ func init() {
 	connectionTestUserType.AddFieldConfig("friends", &graphql.Field{
 		Type: connectionTestConnectionDef.ConnectionType,
 		Args: relay.ConnectionArgs,
-		Resolve: func(p graphql.ResolveParams) interface{} {
+		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			arg := relay.NewConnectionArguments(p.Args)
 			res := relay.ConnectionFromArray(connectionTestAllUsers, arg)
-			return res
+			return res, nil
 		},
 	})
 
@@ -69,8 +69,8 @@ func init() {
 		Fields: graphql.Fields{
 			"user": &graphql.Field{
 				Type: connectionTestUserType,
-				Resolve: func(p graphql.ResolveParams) interface{} {
-					return connectionTestAllUsers[0]
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return connectionTestAllUsers[0], nil
 				},
 			},
 		},

--- a/examples/starwars/schema.go
+++ b/examples/starwars/schema.go
@@ -191,7 +191,7 @@ func init() {
 			"ships": &graphql.Field{
 				Type: shipConnectionDefinition.ConnectionType,
 				Args: relay.ConnectionArgs,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					// convert args map[string]interface into ConnectionArguments
 					args := relay.NewConnectionArguments(p.Args)
 
@@ -205,7 +205,7 @@ func init() {
 					// let relay library figure out the result, given
 					// - the list of ships for this faction
 					// - and the filter arguments (i.e. first, last, after, before)
-					return relay.ConnectionFromArray(ships, args)
+					return relay.ConnectionFromArray(ships, args), nil
 				},
 			},
 		},
@@ -230,14 +230,14 @@ func init() {
 		Fields: graphql.Fields{
 			"rebels": &graphql.Field{
 				Type: factionType,
-				Resolve: func(p graphql.ResolveParams) interface{} {
-					return GetRebels()
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return GetRebels(), nil
 				},
 			},
 			"empire": &graphql.Field{
 				Type: factionType,
-				Resolve: func(p graphql.ResolveParams) interface{} {
-					return GetEmpire()
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return GetEmpire(), nil
 				},
 			},
 			"node": nodeDefinitions.NodeField,
@@ -274,20 +274,20 @@ func init() {
 		OutputFields: graphql.Fields{
 			"ship": &graphql.Field{
 				Type: shipType,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if payload, ok := p.Source.(map[string]interface{}); ok {
-						return GetShip(payload["shipId"].(string))
+						return GetShip(payload["shipId"].(string)), nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"faction": &graphql.Field{
 				Type: factionType,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if payload, ok := p.Source.(map[string]interface{}); ok {
-						return GetFaction(payload["factionId"].(string))
+						return GetFaction(payload["factionId"].(string)), nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 		},

--- a/mutation.go
+++ b/mutation.go
@@ -23,7 +23,7 @@ output field. It may return synchronously, or return a Promise.
 type MutationConfig struct {
 	Name                string                            `json:"name"`
 	InputFields         graphql.InputObjectConfigFieldMap `json:"inputFields"`
-	OutputFields        graphql.Fields            `json:"outputFields"`
+	OutputFields        graphql.Fields                    `json:"outputFields"`
 	MutateAndGetPayload MutationFn                        `json:"mutateAndGetPayload"`
 }
 
@@ -58,15 +58,16 @@ func MutationWithClientMutationID(config MutationConfig) *graphql.Field {
 		Fields: augmentedOutputFields,
 	})
 	return &graphql.Field{
+		Name: config.Name,
 		Type: outputType,
 		Args: graphql.FieldConfigArgument{
 			"input": &graphql.ArgumentConfig{
 				Type: graphql.NewNonNull(inputType),
 			},
 		},
-		Resolve: func(p graphql.ResolveParams) interface{} {
+		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			if config.MutateAndGetPayload == nil {
-				return nil
+				return nil, nil
 			}
 			input := map[string]interface{}{}
 			if inputVal, ok := p.Args["input"]; ok {
@@ -78,7 +79,7 @@ func MutationWithClientMutationID(config MutationConfig) *graphql.Field {
 			if clientMutationID, ok := input["clientMutationId"]; ok {
 				payload["clientMutationId"] = clientMutationID
 			}
-			return payload
+			return payload, nil
 		},
 	}
 }

--- a/node.go
+++ b/node.go
@@ -53,16 +53,16 @@ func NewNodeDefinitions(config NodeDefinitionsConfig) *NodeDefinitions {
 				Description: "The ID of an object",
 			},
 		},
-		Resolve: func(p graphql.ResolveParams) interface{} {
+		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			if config.IDFetcher == nil {
-				return nil
+				return nil, nil
 			}
 			id := ""
 			if iid, ok := p.Args["id"]; ok {
 				id = fmt.Sprintf("%v", iid)
 			}
 			fetchedID := config.IDFetcher(id, p.Info)
-			return fetchedID
+			return fetchedID, nil
 		},
 	}
 	return &NodeDefinitions{
@@ -117,7 +117,7 @@ func GlobalIDField(typeName string, idFetcher GlobalIDFetcherFn) *graphql.Field 
 		Name:        "id",
 		Description: "The ID of an object",
 		Type:        graphql.NewNonNull(graphql.ID),
-		Resolve: func(p graphql.ResolveParams) interface{} {
+		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			id := ""
 			if idFetcher != nil {
 				fetched := idFetcher(p.Source, p.Info)
@@ -135,7 +135,7 @@ func GlobalIDField(typeName string, idFetcher GlobalIDFetcherFn) *graphql.Field 
 				}
 			}
 			globalID := ToGlobalID(typeName, id)
-			return globalID
+			return globalID, nil
 		},
 	}
 }

--- a/node_global_test.go
+++ b/node_global_test.go
@@ -57,13 +57,13 @@ var globalIDTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 		"node": globalIDTestDef.NodeField,
 		"allObjects": &graphql.Field{
 			Type: graphql.NewList(globalIDTestDef.NodeInterface),
-			Resolve: func(p graphql.ResolveParams) interface{} {
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 				return []interface{}{
 					globalIDTestUserData["1"],
 					globalIDTestUserData["2"],
 					globalIDTestPhotoData["1"],
 					globalIDTestPhotoData["2"],
-				}
+				}, nil
 			},
 		},
 	},

--- a/plural.go
+++ b/plural.go
@@ -25,14 +25,14 @@ func PluralIdentifyingRootField(config PluralIdentifyingRootFieldConfig) *graphq
 		Description: config.Description,
 		Type:        graphql.NewList(config.OutputType),
 		Args:        inputArgs,
-		Resolve: func(p graphql.ResolveParams) interface{} {
+		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			inputs, ok := p.Args[config.ArgName]
 			if !ok {
-				return nil
+				return nil, nil
 			}
 
 			if config.ResolveSingleInput == nil {
-				return nil
+				return nil, nil
 			}
 			switch inputs := inputs.(type) {
 			case []interface{}:
@@ -41,9 +41,9 @@ func PluralIdentifyingRootField(config PluralIdentifyingRootFieldConfig) *graphq
 					r := config.ResolveSingleInput(input)
 					res = append(res, r)
 				}
-				return res
+				return res, nil
 			}
-			return nil
+			return nil, nil
 		},
 	}
 }

--- a/plural_test.go
+++ b/plural_test.go
@@ -3,13 +3,13 @@ package relay_test
 import (
 	"fmt"
 	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/testutil"
-	"github.com/graphql-go/relay"
-	"reflect"
-	"testing"
-	"github.com/kr/pretty"
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/location"
+	"github.com/graphql-go/graphql/testutil"
+	"github.com/graphql-go/relay"
+	"github.com/kr/pretty"
+	"reflect"
+	"testing"
 )
 
 var pluralTestUserType = graphql.NewObject(graphql.ObjectConfig{


### PR DESCRIPTION
This is basically identical to #9 except it includes updates to the connection and plural test cases and the starwars example's schema. Thanks to @bsr203 from whom I lifted the `config.Name` addition in `mutation.go`.

As @bsr203 mentions, this introduces compatibility with https://github.com/graphql-go/graphql/commit/344abcc936d3a1f4b288c5c4609377861d1649c5.