### PR TITLE
Adds context support.

### DIFF
--- a/examples/starwars/schema.go
+++ b/examples/starwars/schema.go
@@ -3,6 +3,7 @@ package starwars
 import (
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/relay"
+	"golang.org/x/net/context"
 )
 
 /**
@@ -291,7 +292,7 @@ func init() {
 				},
 			},
 		},
-		MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo) map[string]interface{} {
+		MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) map[string]interface{} {
 			// `inputMap` is a map with keys/fields as specified in `InputFields`
 			// Note, that these fields were specified as non-nullables, so we can assume that it exists.
 			shipName := inputMap["shipName"].(string)

--- a/mutation.go
+++ b/mutation.go
@@ -2,9 +2,10 @@ package relay
 
 import (
 	"github.com/graphql-go/graphql"
+	"golang.org/x/net/context"
 )
 
-type MutationFn func(inputMap map[string]interface{}, info graphql.ResolveInfo) map[string]interface{}
+type MutationFn func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) map[string]interface{}
 
 /*
 A description of a mutation consumable by mutationWithClientMutationId
@@ -75,7 +76,7 @@ func MutationWithClientMutationID(config MutationConfig) *graphql.Field {
 					input = inputVal
 				}
 			}
-			payload := config.MutateAndGetPayload(input, p.Info)
+			payload := config.MutateAndGetPayload(input, p.Info, p.Context)
 			if clientMutationID, ok := input["clientMutationId"]; ok {
 				payload["clientMutationId"] = clientMutationID
 			}

--- a/mutation_test.go
+++ b/mutation_test.go
@@ -1,13 +1,15 @@
 package relay_test
 
 import (
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
-	"reflect"
-	"testing"
-	"time"
+	"golang.org/x/net/context"
 )
 
 func testAsyncDataMutation(resultChan *chan int) {
@@ -24,7 +26,7 @@ var simpleMutationTest = relay.MutationWithClientMutationID(relay.MutationConfig
 			Type: graphql.Int,
 		},
 	},
-	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo) map[string]interface{} {
+	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) map[string]interface{} {
 		return map[string]interface{}{
 			"result": 1,
 		}
@@ -40,7 +42,7 @@ var simplePromiseMutationTest = relay.MutationWithClientMutationID(relay.Mutatio
 			Type: graphql.Int,
 		},
 	},
-	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo) map[string]interface{} {
+	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) map[string]interface{} {
 		c := make(chan int)
 		go testAsyncDataMutation(&c)
 		result := <-c


### PR DESCRIPTION
#### Details.

Issue: #14

- [x] Updates `relay.MutationFn ` signature to expose `Context` recently added on `graphql-go`: https://github.com/graphql-go/graphql/pull/98.

