### PR TITLE
Updates MutationFn signature.

### DIFF
--- a/examples/starwars/mutation_test.go
+++ b/examples/starwars/mutation_test.go
@@ -1,11 +1,12 @@
 package starwars_test
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay/examples/starwars"
-	"reflect"
-	"testing"
 )
 
 func TestMutation_CorrectlyMutatesTheDataSet(t *testing.T) {

--- a/examples/starwars/schema.go
+++ b/examples/starwars/schema.go
@@ -292,7 +292,7 @@ func init() {
 				},
 			},
 		},
-		MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) map[string]interface{} {
+		MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) (map[string]interface{}, error) {
 			// `inputMap` is a map with keys/fields as specified in `InputFields`
 			// Note, that these fields were specified as non-nullables, so we can assume that it exists.
 			shipName := inputMap["shipName"].(string)
@@ -304,7 +304,7 @@ func init() {
 			return map[string]interface{}{
 				"shipId":    newShip.ID,
 				"factionId": factionId,
-			}
+			}, nil
 		},
 	})
 

--- a/mutation.go
+++ b/mutation.go
@@ -5,7 +5,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-type MutationFn func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) map[string]interface{}
+type MutationFn func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) (map[string]interface{}, error)
 
 /*
 A description of a mutation consumable by mutationWithClientMutationId
@@ -76,7 +76,10 @@ func MutationWithClientMutationID(config MutationConfig) *graphql.Field {
 					input = inputVal
 				}
 			}
-			payload := config.MutateAndGetPayload(input, p.Info, p.Context)
+			payload, err := config.MutateAndGetPayload(input, p.Info, p.Context)
+			if err != nil {
+				return nil, err
+			}
 			if clientMutationID, ok := input["clientMutationId"]; ok {
 				payload["clientMutationId"] = clientMutationID
 			}

--- a/mutation_test.go
+++ b/mutation_test.go
@@ -26,10 +26,10 @@ var simpleMutationTest = relay.MutationWithClientMutationID(relay.MutationConfig
 			Type: graphql.Int,
 		},
 	},
-	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) map[string]interface{} {
+	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) (map[string]interface{}, error) {
 		return map[string]interface{}{
 			"result": 1,
-		}
+		}, nil
 	},
 })
 
@@ -42,13 +42,13 @@ var simplePromiseMutationTest = relay.MutationWithClientMutationID(relay.Mutatio
 			Type: graphql.Int,
 		},
 	},
-	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) map[string]interface{} {
+	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) (map[string]interface{}, error) {
 		c := make(chan int)
 		go testAsyncDataMutation(&c)
 		result := <-c
 		return map[string]interface{}{
 			"result": result,
-		}
+		}, nil
 	},
 })
 

--- a/mutation_test.go
+++ b/mutation_test.go
@@ -26,11 +26,7 @@ var simpleMutationTest = relay.MutationWithClientMutationID(relay.MutationConfig
 			Type: graphql.Int,
 		},
 	},
-<<<<<<< HEAD
 	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) (map[string]interface{}, error) {
-=======
-	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo) (map[string]interface{}, error) {
->>>>>>> Fix tests adding error parameter in MutationFn
 		return map[string]interface{}{
 			"result": 1,
 		}, nil
@@ -46,11 +42,7 @@ var simplePromiseMutationTest = relay.MutationWithClientMutationID(relay.Mutatio
 			Type: graphql.Int,
 		},
 	},
-<<<<<<< HEAD
 	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) (map[string]interface{}, error) {
-=======
-	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo) (map[string]interface{}, error) {
->>>>>>> Fix tests adding error parameter in MutationFn
 		c := make(chan int)
 		go testAsyncDataMutation(&c)
 		result := <-c

--- a/mutation_test.go
+++ b/mutation_test.go
@@ -26,7 +26,11 @@ var simpleMutationTest = relay.MutationWithClientMutationID(relay.MutationConfig
 			Type: graphql.Int,
 		},
 	},
+<<<<<<< HEAD
 	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) (map[string]interface{}, error) {
+=======
+	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo) (map[string]interface{}, error) {
+>>>>>>> Fix tests adding error parameter in MutationFn
 		return map[string]interface{}{
 			"result": 1,
 		}, nil
@@ -42,7 +46,11 @@ var simplePromiseMutationTest = relay.MutationWithClientMutationID(relay.Mutatio
 			Type: graphql.Int,
 		},
 	},
+<<<<<<< HEAD
 	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) (map[string]interface{}, error) {
+=======
+	MutateAndGetPayload: func(inputMap map[string]interface{}, info graphql.ResolveInfo) (map[string]interface{}, error) {
+>>>>>>> Fix tests adding error parameter in MutationFn
 		c := make(chan int)
 		go testAsyncDataMutation(&c)
 		result := <-c


### PR DESCRIPTION
#### Details.
Issue: #12

- [x] Updates `relay.MutationFn` signature to possible return an error and a test to verify that.
- [x] Cherry picks commits from initial related [PR](https://github.com/graphql-go/relay/pull/13), thanks @pyros2097 :+1: 