### PR TITLE
Add additional context support

### DIFF
--- a/examples/starwars/schema.go
+++ b/examples/starwars/schema.go
@@ -103,7 +103,7 @@ func init() {
 	 * way we resolve an object that implements node to its type.
 	 */
 	nodeDefinitions = relay.NewNodeDefinitions(relay.NodeDefinitionsConfig{
-		IDFetcher: func(id string, info graphql.ResolveInfo) interface{} {
+		IDFetcher: func(id string, info graphql.ResolveInfo, ctx context.Context) interface{} {
 			// resolve id from global id
 			resolvedID := relay.FromGlobalID(id)
 

--- a/node_global_test.go
+++ b/node_global_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
+	"golang.org/x/net/context"
 	"reflect"
 	"testing"
 )
@@ -29,7 +30,7 @@ var globalIDTestUserType *graphql.Object
 var globalIDTestPhotoType *graphql.Object
 
 var globalIDTestDef = relay.NewNodeDefinitions(relay.NodeDefinitionsConfig{
-	IDFetcher: func(globalID string, info graphql.ResolveInfo) interface{} {
+	IDFetcher: func(globalID string, info graphql.ResolveInfo, ctx context.Context) interface{} {
 		resolvedGlobalID := relay.FromGlobalID(globalID)
 		if resolvedGlobalID == nil {
 			return nil
@@ -83,7 +84,7 @@ func init() {
 		},
 		Interfaces: []*graphql.Interface{globalIDTestDef.NodeInterface},
 	})
-	photoIDFetcher := func(obj interface{}, info graphql.ResolveInfo) string {
+	photoIDFetcher := func(obj interface{}, info graphql.ResolveInfo, ctx context.Context) string {
 		switch obj := obj.(type) {
 		case *photo2:
 			return fmt.Sprintf("%v", obj.PhotoId)

--- a/node_test.go
+++ b/node_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
+	"golang.org/x/net/context"
 	"reflect"
 	"testing"
 )
@@ -33,7 +34,7 @@ var nodeTestUserType *graphql.Object
 var nodeTestPhotoType *graphql.Object
 
 var nodeTestDef = relay.NewNodeDefinitions(relay.NodeDefinitionsConfig{
-	IDFetcher: func(id string, info graphql.ResolveInfo) interface{} {
+	IDFetcher: func(id string, info graphql.ResolveInfo, ctx context.Context) interface{} {
 		if user, ok := nodeTestUserData[id]; ok {
 			return user
 		}


### PR DESCRIPTION
Follow up to PR #15 
- Add context support to `IDFetcherFn` and `GlobalIDFetcherFn`
- Similar to `MutationFn`, both would benefit from context to fetch object for the given id
  - For e.g, the db session for the current request context can be stored in `ctx` in upstream middleware


```go
	nodeDefinitions := relay.NewNodeDefinitions(relay.NodeDefinitionsConfig{
		IDFetcher: func(id string, info graphql.ResolveInfo, ctx context.Context) interface{} {
			db := ctx.Value("db", db) 
			// db connection from a global pool was stored in context earlier, for example

			// resolve id from global id
			resolvedID := relay.FromGlobalID(id)

			// based on id and its type, return the object
			if resolvedID.Type == "Shop" {
				// given resolvedID.ID, fetch `Shop` object from db
				shop := getProduct(db, resolvedID.ID)
				return shop
			}

			// based on id and its type, return the object
			if resolvedID.Type == "Product" {
				// given resolvedID.ID, fetch `Product` object from db
				product := getProduct(db, resolvedID.ID)
				return product
			}
			return nil
		},
		TypeResolve: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
			...
		},
	})
```

/cc: @chris-ramon @pyros2097 @bsr203
