### PR TITLE
Test fixes to use correct ResolveTypeFn and add types to Schema

### DIFF
--- a/examples/starwars/schema.go
+++ b/examples/starwars/schema.go
@@ -2,6 +2,7 @@ package starwars
 
 import (
 	"errors"
+
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/relay"
 	"golang.org/x/net/context"
@@ -118,9 +119,9 @@ func init() {
 				return nil, errors.New("Unknown node type")
 			}
 		},
-		TypeResolve: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
+		TypeResolve: func(p graphql.ResolveTypeParams) *graphql.Object {
 			// based on the type of the value, return GraphQLObjectType
-			switch value.(type) {
+			switch p.Value.(type) {
 			case *Faction:
 				return factionType
 			default:

--- a/node_global_test.go
+++ b/node_global_test.go
@@ -3,12 +3,13 @@ package relay_test
 import (
 	"errors"
 	"fmt"
+	"reflect"
+	"testing"
+
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
 	"golang.org/x/net/context"
-	"reflect"
-	"testing"
 )
 
 type photo2 struct {
@@ -46,14 +47,14 @@ var globalIDTestDef = relay.NewNodeDefinitions(relay.NodeDefinitionsConfig{
 			return nil, errors.New("Unknown node type")
 		}
 	},
-	TypeResolve: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
-		switch value.(type) {
+	TypeResolve: func(p graphql.ResolveTypeParams) *graphql.Object {
+		switch p.Value.(type) {
 		case *user:
 			return globalIDTestUserType
 		case *photo2:
 			return globalIDTestPhotoType
 		default:
-			panic(fmt.Sprintf("Unknown object type `%v`", value))
+			panic(fmt.Sprintf("Unknown object type `%v`", p.Value))
 		}
 	},
 })
@@ -109,6 +110,7 @@ func init() {
 
 	globalIDTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 		Query: globalIDTestQueryType,
+		Types: []graphql.Type{globalIDTestUserType, globalIDTestPhotoType},
 	})
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -3,14 +3,15 @@ package relay_test
 import (
 	"errors"
 	"fmt"
+	"reflect"
+	"testing"
+
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/location"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
 	"golang.org/x/net/context"
-	"reflect"
-	"testing"
 )
 
 type user struct {
@@ -46,14 +47,14 @@ var nodeTestDef = relay.NewNodeDefinitions(relay.NodeDefinitionsConfig{
 		}
 		return nil, errors.New("Unknown node")
 	},
-	TypeResolve: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
-		switch value.(type) {
+	TypeResolve: func(p graphql.ResolveTypeParams) *graphql.Object {
+		switch p.Value.(type) {
 		case *user:
 			return nodeTestUserType
 		case *photo:
 			return nodeTestPhotoType
 		default:
-			panic(fmt.Sprintf("Unknown object type `%v`", value))
+			panic(fmt.Sprintf("Unknown object type `%v`", p.Value))
 		}
 	},
 })
@@ -64,7 +65,7 @@ var nodeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 	},
 })
 
-// becareful not to define schema here, since nodeTestUserType and nodeTestPhotoType wouldn't be defined till init()
+// be careful not to define schema here, since nodeTestUserType and nodeTestPhotoType wouldn't be defined till init()
 var nodeTestSchema graphql.Schema
 
 func init() {
@@ -95,6 +96,7 @@ func init() {
 
 	nodeTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 		Query: nodeTestQueryType,
+		Types: []graphql.Type{nodeTestUserType, nodeTestPhotoType},
 	})
 }
 func TestNodeInterfaceAndFields_AllowsRefetching_GetsTheCorrectIDForUsers(t *testing.T) {


### PR DESCRIPTION
Fixes for tests, so they cooperate with the current version of [graphql](https://github.com/graphql-go/graphql).  See issue #26.
