### PR TITLE
Prefer standard library package

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -1,11 +1,12 @@
 package relay_test
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
-	"reflect"
-	"testing"
 )
 
 var connectionTestAllUsers = []interface{}{

--- a/examples/starwars/schema.go
+++ b/examples/starwars/schema.go
@@ -1,11 +1,11 @@
 package starwars
 
 import (
+	"context"
 	"errors"
 
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/relay"
-	"golang.org/x/net/context"
 )
 
 /**

--- a/mutation.go
+++ b/mutation.go
@@ -1,8 +1,9 @@
 package relay
 
 import (
+	"context"
+
 	"github.com/graphql-go/graphql"
-	"golang.org/x/net/context"
 )
 
 type MutationFn func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) (map[string]interface{}, error)

--- a/mutation_test.go
+++ b/mutation_test.go
@@ -1,6 +1,7 @@
 package relay_test
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -11,7 +12,6 @@ import (
 	"github.com/graphql-go/graphql/language/location"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
-	"golang.org/x/net/context"
 )
 
 func testAsyncDataMutation(resultChan *chan int) {

--- a/node.go
+++ b/node.go
@@ -1,13 +1,13 @@
 package relay
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/graphql-go/graphql"
-	"golang.org/x/net/context"
 )
 
 type NodeDefinitions struct {

--- a/node.go
+++ b/node.go
@@ -4,9 +4,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/graphql-go/graphql"
 	"golang.org/x/net/context"
-	"strings"
 )
 
 type NodeDefinitions struct {

--- a/node_global_test.go
+++ b/node_global_test.go
@@ -1,6 +1,7 @@
 package relay_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -9,7 +10,6 @@ import (
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
-	"golang.org/x/net/context"
 )
 
 type photo2 struct {

--- a/node_test.go
+++ b/node_test.go
@@ -1,6 +1,7 @@
 package relay_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -11,7 +12,6 @@ import (
 	"github.com/graphql-go/graphql/language/location"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
-	"golang.org/x/net/context"
 )
 
 type user struct {

--- a/plural_test.go
+++ b/plural_test.go
@@ -2,14 +2,15 @@ package relay_test
 
 import (
 	"fmt"
+	"reflect"
+	"testing"
+
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/location"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
 	"github.com/kr/pretty"
-	"reflect"
-	"testing"
 )
 
 var pluralTestUserType = graphql.NewObject(graphql.ObjectConfig{


### PR DESCRIPTION
This package has been available in the Go standard library since version 1.7 and the other GraphQL packages for Go use the shortest import path too.

(Let me know if I should remove the first commit; import paths seemed to be generally grouped so I made this true for all files.)