### PR TITLE
fix: change ConnectionConfig.NodeType

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -29,10 +29,10 @@ func NewConnectionArgs(configMap graphql.FieldConfigArgument) graphql.FieldConfi
 }
 
 type ConnectionConfig struct {
-	Name             string          `json:"name"`
-	NodeType         *graphql.Object `json:"nodeType"`
-	EdgeFields       graphql.Fields  `json:"edgeFields"`
-	ConnectionFields graphql.Fields  `json:"connectionFields"`
+	Name             string         `json:"name"`
+	NodeType         graphql.Output `json:"nodeType"`
+	EdgeFields       graphql.Fields `json:"edgeFields"`
+	ConnectionFields graphql.Fields `json:"connectionFields"`
 }
 
 type EdgeType struct {


### PR DESCRIPTION
ConnectionDefinitions does not support Interfaces

Changing ConnectionConfig.NodeType from graphql.Object to graphql.Output enables this

Resolves #42 