### PR TITLE
use stdlib context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.4
+  - 1.7
 
 before_install:
   - go get github.com/axw/gocov/gocov

--- a/examples/starwars/schema.go
+++ b/examples/starwars/schema.go
@@ -1,11 +1,11 @@
 package starwars
 
 import (
+	"context"
 	"errors"
 
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/relay"
-	"golang.org/x/net/context"
 )
 
 /**

--- a/mutation.go
+++ b/mutation.go
@@ -1,8 +1,9 @@
 package relay
 
 import (
+	"context"
+
 	"github.com/graphql-go/graphql"
-	"golang.org/x/net/context"
 )
 
 type MutationFn func(inputMap map[string]interface{}, info graphql.ResolveInfo, ctx context.Context) (map[string]interface{}, error)

--- a/mutation_test.go
+++ b/mutation_test.go
@@ -1,6 +1,7 @@
 package relay_test
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -11,7 +12,6 @@ import (
 	"github.com/graphql-go/graphql/language/location"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
-	"golang.org/x/net/context"
 )
 
 func testAsyncDataMutation(resultChan *chan int) {

--- a/node.go
+++ b/node.go
@@ -1,12 +1,13 @@
 package relay
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/graphql-go/graphql"
-	"golang.org/x/net/context"
 	"strings"
+
+	"github.com/graphql-go/graphql"
 )
 
 type NodeDefinitions struct {

--- a/node_global_test.go
+++ b/node_global_test.go
@@ -1,6 +1,7 @@
 package relay_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -9,7 +10,6 @@ import (
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
-	"golang.org/x/net/context"
 )
 
 type photo2 struct {

--- a/node_test.go
+++ b/node_test.go
@@ -1,6 +1,7 @@
 package relay_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -11,7 +12,6 @@ import (
 	"github.com/graphql-go/graphql/language/location"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/relay"
-	"golang.org/x/net/context"
 )
 
 type user struct {


### PR DESCRIPTION
The main repo (graphql-go/graphql) uses standard library context. So we should use it here too.
I also upgraded go version in travis.
